### PR TITLE
fix tiny typo

### DIFF
--- a/CRM/Activityical/Form/Details.php
+++ b/CRM/Activityical/Form/Details.php
@@ -32,7 +32,7 @@ class CRM_Activityical_Form_Details extends CRM_Core_Form {
         'id' => $this->contact_id,
       );
       try {
-        $result = _activityical_civicrmapi('contact', 'get', $api_params. FALSE);
+        $result = _activityical_civicrmapi('contact', 'get', $api_params, FALSE);
       }
       catch (CiviCRM_API3_Exception $e) {
           CRM_Core_Error::statusBounce($not_found_error);


### PR DESCRIPTION
I noticed the use of a point instead of a comma to seperate the params.