### PR TITLE
Tag 1.9.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,12 +14,11 @@
     <url desc="Support">https://github.com/twomice/com.joineryhq.activityical/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/gpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-09-23</releaseDate>
-  <version>1.8.0</version>
+  <releaseDate>2024-09-11</releaseDate>
+  <version>1.9.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.7</ver>
-    <ver>5.0</ver>
+    <ver>5.69</ver>
   </compatibility>
   <comments>Based on http://drupal.org/project/civicrm_activity_ical, CMS-independent extension development sponsored by The Saturday Light Brigade.</comments>
   <civix>


### PR DESCRIPTION
I also updated min version to 5.69 - which is when the smarty updates go back to. It should be backward compatible etc but really you don't want really old sites grabbing the latest release & then putting up support requests....


@twomice can you tag a release?