### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/activityical.php
+++ b/activityical.php
@@ -97,7 +97,7 @@ function activityical_civicrm_pageRun(&$page) {
     if (_activityical_contact_has_feed_group($contact_id)) {
       $tpl = CRM_Core_Smarty::singleton();
       // Only if this CiviCRM is showing activities on the user dashboard
-      if (isset($tpl->get_template_vars()['activity_rows']) || isset($tpl->get_template_vars()['activity_rowsEmpty'])) {
+      if (isset($tpl->getTemplateVars()['activity_rows']) || isset($tpl->getTemplateVars()['activity_rowsEmpty'])) {
         $url_query = array(
           'contact_id' => $contact_id,
         );


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.