### PR TITLE
work with smarty 5

### DIFF
--- a/activityical.php
+++ b/activityical.php
@@ -37,9 +37,7 @@ function _activityical_check_permission($access_arguments, $op) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
  */
 function activityical_civicrm_config(&$config) {
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-  $template =& CRM_Core_Smarty::singleton();
-  $template->plugins_dir = array_merge(array($extRoot . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins'), (array) $template->plugins_dir);
+  CRM_Core_Smarty::singleton()->addPluginsDir(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Smarty' . DIRECTORY_SEPARATOR . 'plugins');
 
   _activityical_civix_civicrm_config($config);
 }


### PR DESCRIPTION
Before
-------
* On the drupal side, every page has `Warning: Undefined property: Smarty\Smarty::$plugins_dir in Smarty->__get() (line 37 of sites\all\modules\civicrm\packages\smarty5\Smarty.php)`
* Then when you try to download a feed it crashes: `Syntax error in template "file:CRM/Activityical/snippet/Feed.tpl" on line 34 "{$activity.description|activityicalHtml}" unknown modifier 'activityicalHtml'`

After
-----
Not those.

Comments
------------
This will still work with smarty 2 if on civi 5.74+. The info file has 5.69 but maybe it's time to bump?